### PR TITLE
feat(autoforager/compatibility): Add general compatibility

### DIFF
--- a/src/AutoForager/AutoForager.csproj
+++ b/src/AutoForager/AutoForager.csproj
@@ -6,7 +6,7 @@
     <UniqueId>HedgehogTechnologies.AutoForager</UniqueId>
     <Name>Auto Forager</Name>
     <Authors>Jag3Dagster</Authors>
-    <Description>Automatically shake bushes and trees as you walk by.</Description>
+    <Description>Automatically forage items simply by moving near them.</Description>
     <Version>2.2.0</Version>
     <UpdateKeys>Nexus:7736</UpdateKeys>
 
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <SMAPIDependency Include="spacechase0.GenericModConfigMenu" Required="false" />
-    <SMAPIDependency Include="FlashShifter.StardewValleyExpandedCP" Required="false" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/AutoForager/AutoForager.csproj
+++ b/src/AutoForager/AutoForager.csproj
@@ -7,7 +7,7 @@
     <Name>Auto Forager</Name>
     <Authors>Jag3Dagster</Authors>
     <Description>Automatically shake bushes and trees as you walk by.</Description>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <UpdateKeys>Nexus:7736</UpdateKeys>
 
     <MinimumApiVersion>auto</MinimumApiVersion>
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <SMAPIDependency Include="spacechase0.GenericModConfigMenu" Required="false" />
+    <SMAPIDependency Include="FlashShifter.StardewValleyExpandedCP" Required="false" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/AutoForager/Classes/ForageableItem.cs
+++ b/src/AutoForager/Classes/ForageableItem.cs
@@ -10,6 +10,8 @@ using StardewValley.ItemTypeDefinitions;
 using StardewValley.TokenizableStrings;
 using AutoForager.Helpers;
 
+using Constants = AutoForager.Helpers.Constants;
+
 namespace AutoForager.Classes
 {
     public class ForageableItem : IComparable
@@ -127,14 +129,23 @@ namespace AutoForager.Classes
 
                 var qualifiedItemId = "(O)" + kvp.Key;
                 var enabled = false;
-                var itemData = ItemRegistry.GetData(qualifiedItemId);
+                var itemData = ItemRegistry.GetData(qualifiedItemId) ?? ItemRegistry.GetData(kvp.Key);
+                var internalName = itemData?.InternalName ?? kvp.Value.Name;
 
-                if (configValues != null && configValues.TryGetValue(itemData.InternalName, out var configEnabled))
+                if (configValues != null && configValues.TryGetValue(internalName, out var configEnabled))
                 {
                     enabled = configEnabled;
                 }
 
-                forageItems.AddDistinct(new ForageableItem(itemData, customFields, enabled));
+                if (itemData != null)
+                {
+                    forageItems.AddDistinct(new ForageableItem(itemData, customFields, enabled));
+                }
+                else
+                {
+                    var kvpValue = kvp.Value;
+                    forageItems.AddDistinct(new ForageableItem(kvp.Key, qualifiedItemId, kvpValue.Name, kvpValue.DisplayName, kvpValue.CustomFields, enabled));
+                }
             }
 
             return forageItems;

--- a/src/AutoForager/Helpers/CategoryComparer.cs
+++ b/src/AutoForager/Helpers/CategoryComparer.cs
@@ -13,6 +13,8 @@ namespace AutoForager.Helpers
             }
 
             if (x.Equals(y)) return 0;
+            if (x.Equals("Stardew Valley Expanded")) return 1;
+            if (y.Equals("Stardew Valley Expanded")) return -1;
             if (x.Equals("Other")) return 1;
             if (y.Equals("Other")) return -1;
             if (x.Equals("Special")) return 1;

--- a/src/AutoForager/Helpers/Constants.cs
+++ b/src/AutoForager/Helpers/Constants.cs
@@ -31,7 +31,7 @@ namespace AutoForager.Helpers
         public static string ObjectsAssetName => _objectsAssetName;
 
         private const string _wildTreesAssetName = "Data/WildTrees";
-        public static string WildTreesAssetName = _wildTreesAssetName;
+        public static string WildTreesAssetName => _wildTreesAssetName;
 
         #endregion Asset Properties
 
@@ -97,6 +97,9 @@ namespace AutoForager.Helpers
 
         private const string _requireHoeId = _fieldIdPrefix + "RequireHoe";
         public static string RequireHoeId => _requireHoeId;
+
+        private const string _requireToolMossId = _fieldIdPrefix + "RequireToolMoss";
+        public static string RequireToolMossId => _requireToolMossId;
 
         private const string _bushesPageId = _fieldIdPrefix + "BushesPage";
         public static string BushesPageId => _bushesPageId;
@@ -176,22 +179,9 @@ namespace AutoForager.Helpers
             { "88", "Desert" },     // Coconut
 
             { "829", "Special" },   // Ginger
+            { "Moss", "Special" },  // Moss
             { "399", "Special" },   // Sping Onion
             { "430", "Special" },   // Truffle
-
-            // Stardew Valley Expanded
-            { "FlashShifter.StardewValleyExpandedCP_Bearberrys", "Stardew Valley Expanded" },             // Bearberry
-            { "FlashShifter.StardewValleyExpandedCP_Big_Conch", "Stardew Valley Expanded" },              // Conch
-            { "FlashShifter.StardewValleyExpandedCP_Dried_Sand_Dollar", "Stardew Valley Expanded" },      // Sand Dollar
-            { "FlashShifter.StardewValleyExpandedCP_Ferngill_Primrose", "Stardew Valley Expanded" },      // Ferngill Primrose
-            { "FlashShifter.StardewValleyExpandedCP_Goldenrod", "Stardew Valley Expanded" },              // Goldenrod
-            { "FlashShifter.StardewValleyExpandedCP_Lucky_Four_Leaf_Clover", "Stardew Valley Expanded" }, // Four Leaf Clover
-            { "FlashShifter.StardewValleyExpandedCP_Mushroom_Colony", "Stardew Valley Expanded" },        // Mushroom Colony
-            { "FlashShifter.StardewValleyExpandedCP_Poison_Mushroom", "Stardew Valley Expanded" },        // Poison Mushroom
-            { "FlashShifter.StardewValleyExpandedCP_Red_Baneberry", "Stardew Valley Expanded" },          // Red Baneberry
-            { "FlashShifter.StardewValleyExpandedCP_Smelly_Rafflesia", "Stardew Valley Expanded" },       // Rafflesia
-            { "FlashShifter.StardewValleyExpandedCP_Thistle", "Stardew Valley Expanded" },                // Thistle
-            { "FlashShifter.StardewValleyExpandedCP_Winter_Star_Rose", "Stardew Valley Expanded" },       // Winter Star Rose
         };
         public static Dictionary<string, string> KnownCategoryLookup => _knownCategoryLookup;
 
@@ -211,5 +201,14 @@ namespace AutoForager.Helpers
             "(O)FlashShifter.StardewValleyExpandedCP_Winter_Star_Rose"
         };
         public static List<string> SVEForageables => _sveForageables;
+
+        private static readonly Dictionary<string, string> _knownModPrefixes = new()
+        {
+            { "Cornucopia", "Cornucopia" },
+            { "FlashShifter.StardewValleyExpandedCP", "Stardew Valley Expanded" },
+            { "FlashShifter.SVE-FTM", "Stardew Valley Expanded" },
+            { "FlashShifter.SVECode", "Stardew Valley Expanded" }
+        };
+        public static Dictionary<string, string> KnownModPrefixes => _knownModPrefixes;
     }
 }

--- a/src/AutoForager/Helpers/Constants.cs
+++ b/src/AutoForager/Helpers/Constants.cs
@@ -178,7 +178,38 @@ namespace AutoForager.Helpers
             { "829", "Special" },   // Ginger
             { "399", "Special" },   // Sping Onion
             { "430", "Special" },   // Truffle
+
+            // Stardew Valley Expanded
+            { "FlashShifter.StardewValleyExpandedCP_Bearberrys", "Stardew Valley Expanded" },             // Bearberry
+            { "FlashShifter.StardewValleyExpandedCP_Big_Conch", "Stardew Valley Expanded" },              // Conch
+            { "FlashShifter.StardewValleyExpandedCP_Dried_Sand_Dollar", "Stardew Valley Expanded" },      // Sand Dollar
+            { "FlashShifter.StardewValleyExpandedCP_Ferngill_Primrose", "Stardew Valley Expanded" },      // Ferngill Primrose
+            { "FlashShifter.StardewValleyExpandedCP_Goldenrod", "Stardew Valley Expanded" },              // Goldenrod
+            { "FlashShifter.StardewValleyExpandedCP_Lucky_Four_Leaf_Clover", "Stardew Valley Expanded" }, // Four Leaf Clover
+            { "FlashShifter.StardewValleyExpandedCP_Mushroom_Colony", "Stardew Valley Expanded" },        // Mushroom Colony
+            { "FlashShifter.StardewValleyExpandedCP_Poison_Mushroom", "Stardew Valley Expanded" },        // Poison Mushroom
+            { "FlashShifter.StardewValleyExpandedCP_Red_Baneberry", "Stardew Valley Expanded" },          // Red Baneberry
+            { "FlashShifter.StardewValleyExpandedCP_Smelly_Rafflesia", "Stardew Valley Expanded" },       // Rafflesia
+            { "FlashShifter.StardewValleyExpandedCP_Thistle", "Stardew Valley Expanded" },                // Thistle
+            { "FlashShifter.StardewValleyExpandedCP_Winter_Star_Rose", "Stardew Valley Expanded" },       // Winter Star Rose
         };
         public static Dictionary<string, string> KnownCategoryLookup => _knownCategoryLookup;
+
+        private static readonly List<string> _sveForageables = new()
+        {
+            "(O)FlashShifter.StardewValleyExpandedCP_Bearberrys",
+            "(O)FlashShifter.StardewValleyExpandedCP_Big_Conch",
+            "(O)FlashShifter.StardewValleyExpandedCP_Dried_Sand_Dollar",
+            "(O)FlashShifter.StardewValleyExpandedCP_Ferngill_Primrose",
+            "(O)FlashShifter.StardewValleyExpandedCP_Goldenrod",
+            "(O)FlashShifter.StardewValleyExpandedCP_Lucky_Four_Leaf_Clover",
+            "(O)FlashShifter.StardewValleyExpandedCP_Mushroom_Colony",
+            "(O)FlashShifter.StardewValleyExpandedCP_Poison_Mushroom",
+            "(O)FlashShifter.StardewValleyExpandedCP_Red_Baneberry",
+            "(O)FlashShifter.StardewValleyExpandedCP_Smelly_Rafflesia",
+            "(O)FlashShifter.StardewValleyExpandedCP_Thistle",
+            "(O)FlashShifter.StardewValleyExpandedCP_Winter_Star_Rose"
+        };
+        public static List<string> SVEForageables => _sveForageables;
     }
 }

--- a/src/AutoForager/Helpers/ListExtensions.cs
+++ b/src/AutoForager/Helpers/ListExtensions.cs
@@ -18,15 +18,15 @@ namespace AutoForager.Helpers
             items.Sort((x, y) => string.CompareOrdinal(x.DisplayName, y.DisplayName));
         }
 
-        public static bool TryGetItem(this List<ForageableItem> items, string itemId, out ForageableItem? item)
+        public static bool TryGetItem(this List<ForageableItem> items, string qualifiedItemId, out ForageableItem? item)
         {
             item = null;
 
-            if (items is null || itemId is null) return false;
+            if (items is null || qualifiedItemId is null) return false;
 
             foreach (var fItem in items)
             {
-                if (fItem.QualifiedItemId.IEquals(itemId))
+                if (fItem.QualifiedItemId.IEquals(qualifiedItemId))
                 {
                     item = fItem;
                     return true;

--- a/src/AutoForager/ModEntry.cs
+++ b/src/AutoForager/ModEntry.cs
@@ -565,6 +565,8 @@ namespace AutoForager
 
         private void OnPlayerWarped(object? sender, WarpedEventArgs e)
         {
+            if (!e.IsLocalPlayer) return;
+
             _artifactPredictions.Clear();
 
             var mapLoc = e.NewLocation;

--- a/src/AutoForager/ModEntry.cs
+++ b/src/AutoForager/ModEntry.cs
@@ -364,6 +364,7 @@ namespace AutoForager
                                 }
 
                                 tree.performToolAction(tool, -1, tree.Tile);
+                                _trackingCounts[Constants.ForageableKey].AddOrIncrement(mossItem.DisplayName);
                             }
 
                             break;

--- a/src/AutoForager/ModEntry.cs
+++ b/src/AutoForager/ModEntry.cs
@@ -182,6 +182,11 @@ namespace AutoForager
             _config = helper.ReadConfig<ModConfig>();
             _config.UpdateEnabled(helper);
 
+            if (Helper.ModRegistry.IsLoaded("FlashShifter.StardewValleyExpandedCP"))
+            {
+                _overrideItemIds.AddRange(Constants.SVEForageables);
+            }
+
             helper.Events.Content.AssetReady += OnAssetReady;
             helper.Events.Content.AssetRequested += OnAssetRequested;
             helper.Events.GameLoop.DayEnding += OnDayEnding;
@@ -216,6 +221,7 @@ namespace AutoForager
             }
         }
 
+        [EventPriority(EventPriority.Low)]
         private void OnAssetRequested(object? sender, AssetRequestedEventArgs e)
         {
             var assetName = e.Name.BaseName;
@@ -668,10 +674,10 @@ namespace AutoForager
 
             foreach (var obj in objectData.Data)
             {
-                if (_ignoreItemIds.Any(i => obj.Key.Equals(i.Substring(3)))) continue;
+                if (_ignoreItemIds.Any(i => obj.Key.IEquals(i.Substring(3)))) continue;
 
                 if ((obj.Value.ContextTags?.Contains("forage_item") ?? false)
-                    || _overrideItemIds.Any(i => obj.Key.Equals(i.Substring(3))))
+                    || _overrideItemIds.Any(i => obj.Key.IEquals(i.Substring(3))))
                 {
                     obj.Value.CustomFields ??= new();
                     obj.Value.CustomFields.AddOrUpdate(Constants.CustomFieldForageableKey, "true");

--- a/src/AutoForager/README.md
+++ b/src/AutoForager/README.md
@@ -63,6 +63,8 @@ Releases can be found on [GitHub](https://github.com/Hedgehog-Technologies/Stard
 - Added compatibility with Stardew Valley Expanded forageable items
 - Added "Moss" as a forageable option
   - Added option to toggle off requirement of having a tool in inventory for Auto Forager to forage for Moss
+- Added partial compatibility for the Cornucopia mod
+  - Additional work is needed to added compatibility with the "Custom Bush" mod
 - Custom Wild and Fruit trees are now properly recognized by the Auto Forager
 - Fixed a potential crash when running alongside the "Marry Morris" mod
 ### 2.1.0

--- a/src/AutoForager/README.md
+++ b/src/AutoForager/README.md
@@ -59,6 +59,12 @@ Ukrainian  | ✔              | ❌                   | ❌
 
 ## Releases
 Releases can be found on [GitHub](https://github.com/Hedgehog-Technologies/StardewMods/releases), on the [Nexus Mod](https://www.nexusmods.com/stardewvalley/mods/7736) site, and on the [CurseForge](https://www.curseforge.com/stardewvalley/mods/auto-forager) site.
+### 2.2.0
+- Added compatibility with Stardew Valley Expanded forageable items
+- Added "Moss" as a forageable option
+  - Added option to toggle off requirement of having a tool in inventory for Auto Forager to forage for Moss
+- Custom Wild and Fruit trees are now properly recognized by the Auto Forager
+- Fixed a potential crash when running alongside the "Marry Morris" mod
 ### 2.1.0
 - Added ability to forage for truffles found by pigs
 - Wild Trees added in 1.6 are now shaken as expected

--- a/src/AutoForager/i18n/default.json
+++ b/src/AutoForager/i18n/default.json
@@ -15,10 +15,12 @@
   "Log.Eod.Stat": "\t[{{amount}}] {{subjects}}",
   "Log.Eod.TotalStat": "[{{amount}}] Total Forages",
   "Log.FruitNotReady": "Fruit trees will not be shaken until they have {{amount}} fruits available. This can be set with the {{configName}} config setting.",
-  "Log.MissingHoe": "{{subject}} will not be foraged because no Hoe was found in the player's inventory. This settings can be turned off by disabling {{configName}}",
+  "Log.MissingHoe": "{{subject}} will not be foraged because no Hoe was found in the player's inventory. This setting can be turned off by disabling {{configName}}",
+  "Log.MissingToolMoss": "Moss will not be foraged because no Tool was found in the player's inventory. This setting can be turned off by disabling {{configName}}",
 
   "Message.AutoForagerToggled": "AutoForager has been {{state}}",
   "Message.MissingHoe": "Missing a Hoe. You can't forage {{subject}} without one.",
+  "Message.MissingToolMoss": "Missing a tool. You can't forage Moss without a tool.",
 
   "Note.ShakeWalnutBushes": "These walnuts are meant to be end game content and difficult to find. Enabling this option does trivialize this content to some degree.",
 
@@ -28,6 +30,8 @@
   "Option.IsForagerActive.Tooltip": "Whether or not the AutoForager will shake trees and bushes and forage for objects.",
   "Option.RequireHoe.Name": "Require Hoe for Ginger roots,{{whitespace}}Snow Yams, and Winter Roots?",
   "Option.RequireHoe.Tooltip": "Whether or not a player is required to have a hoe in their inventory to forage for some items, such as Ginger and Snow Yams.",
+  "Option.RequireToolMoss.Name": "Require any tool for foraging{{whitespace}}Moss from trees?",
+  "Option.RequireToolMoss.Tooltip": "Whether or not a player is required to have any tool in their inventory to forage for Moss from trees.",
   "Option.ShakeDistance.Name": "Shake Distance",
   "Option.ShakeDistance.Tooltip": "Distance to shake bushes when '{{playerMagnetismName}}' is disabled.",
   "Option.ToggleAction.Name": "Forage any {{subject}}?",
@@ -45,7 +49,7 @@
   "Page.FruitTrees.Title": "Fruit Trees",
   "Page.FruitTrees.Description": "Whether or not the following items should be shaken from Fruit Trees:",
   "Page.WildTrees.Title": "Wild Trees",
-  "Page.WildTrees.Description": "Whether or not the following items should be shaken from Wild Trees or foraged from :",
+  "Page.WildTrees.Description": "Whether or not the following items should be shaken from Wild Trees:",
 
   "Reward.Blackberries": "Blackberries",
   "Reward.GoldenWalnuts": "Golden Walnuts",


### PR DESCRIPTION
- Add compatibility for recognizing custom trees added by other mods
  - Addresses part of #8 but additional work is needed to for compatibility with [Custom Bush](https://www.nexusmods.com/stardewvalley/mods/20619) 
- Add specific Stardew Valley Expanded compatibility for forageables
  - Resolves #4 
- Add Moss as a forageable
  - Additional toggleable check for any tools in inventory
  - Resolves #7 
- Fixes potential crash when paired with [Marry Morris](https://www.nexusmods.com/stardewvalley/mods/12824)
  - Resolves #9 
