### PR TITLE
feat(autoforager): Add FTM integration

### DIFF
--- a/src/AutoForager/AutoForager.csproj
+++ b/src/AutoForager/AutoForager.csproj
@@ -7,7 +7,7 @@
     <Name>Auto Forager</Name>
     <Authors>Jag3Dagster</Authors>
     <Description>Automatically forage items simply by moving near them.</Description>
-    <Version>3.4.3</Version>
+    <Version>3.5.0</Version>
     <UpdateKeys>Nexus:7736</UpdateKeys>
 
     <MinimumApiVersion>auto</MinimumApiVersion>
@@ -19,6 +19,7 @@
     <SMAPIDependency Include="NCarigon.BushBloomMod" Required="false" />
     <SMAPIDependency Include="Pathoschild.ContentPatcher" Required="false" />
     <SMAPIDependency Include="furyx639.CustomBush" Required="false" />
+    <SMAPIDependency Include="Esca.FarmTypeManager" Required="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AutoForager/Classes/CategoryComparer.cs
+++ b/src/AutoForager/Classes/CategoryComparer.cs
@@ -1,13 +1,15 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using StardewModdingAPI;
+using HedgeTech.Common.Extensions;
 
 namespace AutoForager.Classes
 {
 	internal class CategoryComparer : IComparer<string>
 	{
 		private readonly List<string> _packCategories = new();
+		private readonly List<string> _ftmCategories = new();
 
 		int IComparer<string>.Compare(string? x, string? y)
 		{
@@ -24,15 +26,18 @@ namespace AutoForager.Classes
 
 			var xIsPack = _packCategories.Contains(x);
 			var yIsPack = _packCategories.Contains(y);
-			if (xIsPack && yIsPack)
+			var xIsFtm = _ftmCategories.Contains(x);
+			var yIsFtm = _ftmCategories.Contains(y);
+
+			if ((xIsPack || xIsFtm) && (yIsPack || yIsFtm))
 			{
 				return string.Compare(x, y);
 			}
-			else if (xIsPack)
+			else if (xIsPack || xIsFtm)
 			{
 				return 1;
 			}
-			else if (yIsPack)
+			else if (yIsPack || yIsFtm)
 			{
 				return -1;
 			}
@@ -45,6 +50,14 @@ namespace AutoForager.Classes
 			if (y.Equals(I18n.Category_Vanilla(), StringComparison.InvariantCultureIgnoreCase)) return 1;
 
 			return string.Compare(x, y);
+		}
+
+		public void AddFtmCategories(Dictionary<string, string> ftmCategories)
+		{
+			foreach (var value in ftmCategories.Values)
+			{
+				_ftmCategories.AddDistinct(value);
+			}
 		}
 
 		public CategoryComparer(IEnumerable<IContentPack> packs)

--- a/src/AutoForager/Helpers/Constants.cs
+++ b/src/AutoForager/Helpers/Constants.cs
@@ -151,23 +151,18 @@ namespace AutoForager.Helpers
 		private static readonly Dictionary<string, string> _knownCategoryLookup = new()
 		{
 			{ "107", "Category.Animal" },    // Dinosaur Egg
-			{ "174", "Category.Animal" },    // Large Egg (white)
-			{ "176", "Category.Animal" },    // Egg (white)
-			{ "180", "Category.Animal" },    // Egg (brown)
-			{ "182", "Category.Animal" },    // Large Egg (brown)
-			{ "289", "Category.Animal" },    // Ostrich Egg
-			{ "305", "Category.Animal" },    // Void Egg
-			{ "413", "Category.Animal" },    // Blue Slime Egg
-			{ "430", "Category.Animal" },    // Truffle
-			{ "437", "Category.Animal" },    // Red Slime Egg
-			{ "439", "Category.Animal" },    // Purple Slime Egg
-			{ "440", "Category.Animal" },    // Wool
 			{ "442", "Category.Animal" },    // Duck Egg
 			{ "444", "Category.Animal" },    // Duck Feather
-			{ "446", "Category.Animal" },    // Rabbit's Foot
-			{ "680", "Category.Animal" },    // Green Slime Egg
-			{ "857", "Category.Animal" },    // Tiger Slime Egg
+			{ "180", "Category.Animal" },    // Egg (brown)
+			{ "176", "Category.Animal" },    // Egg (white)
 			{ "928", "Category.Animal" },    // Golden Egg
+			{ "182", "Category.Animal" },    // Large Egg (brown)
+			{ "174", "Category.Animal" },    // Large Egg (white)
+			{ "289", "Category.Animal" },    // Ostrich Egg
+			{ "446", "Category.Animal" },    // Rabbit's Foot
+			{ "430", "Category.Animal" },    // Truffle
+			{ "305", "Category.Animal" },    // Void Egg
+			{ "440", "Category.Animal" },    // Wool
 
 			{ "18", "Category.Spring" },     // Daffodil
 			{ "22", "Category.Spring" },     // Dandelion
@@ -209,8 +204,15 @@ namespace AutoForager.Helpers
 			{ "90", "Category.Desert" },     // Cactus Fruit
 			{ "88", "Category.Desert" },     // Coconut
 
+			{ "613",  "Category.Special" },  // Apple
+			{ "634",  "Category.Special" },  // Apricot
+			{ "638",  "Category.Special" },  // Cherry
 			{ "829",  "Category.Special" },  // Ginger
 			{ "Moss", "Category.Special" },  // Moss
+			{ "635",  "Cateogry.Special" },  // Orange
+			{ "636",  "Category.Special" },  // Peach
+			{ "637",  "Category.Special" },  // Pomegranate
+			{ "296",  "Category.Special" },  // Salmonberry
 			{ "399",  "Category.Special" },  // Sping Onion
 		};
 		public static Dictionary<string, string> KnownCategoryLookup => _knownCategoryLookup;
@@ -250,5 +252,12 @@ namespace AutoForager.Helpers
 			"410"  // Blackberry
 		};
 		public static List<string> VanillaBushBlooms => _vanillaBushBlooms;
+
+		private static readonly Dictionary<string, int> _bigCraftableXpLookup = new()
+		{
+			{ "(BC)128", 5 },
+			{ "(BC)MushroomLog", 5 }
+		};
+		public static Dictionary<string, int> BigCraftableXpLookup => _bigCraftableXpLookup;
 	}
 }

--- a/src/AutoForager/Helpers/Constants.cs
+++ b/src/AutoForager/Helpers/Constants.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace AutoForager.Helpers
 {
@@ -150,6 +150,25 @@ namespace AutoForager.Helpers
 
 		private static readonly Dictionary<string, string> _knownCategoryLookup = new()
 		{
+			{ "107", "Category.Animal" },    // Dinosaur Egg
+			{ "174", "Category.Animal" },    // Large Egg (white)
+			{ "176", "Category.Animal" },    // Egg (white)
+			{ "180", "Category.Animal" },    // Egg (brown)
+			{ "182", "Category.Animal" },    // Large Egg (brown)
+			{ "289", "Category.Animal" },    // Ostrich Egg
+			{ "305", "Category.Animal" },    // Void Egg
+			{ "413", "Category.Animal" },    // Blue Slime Egg
+			{ "430", "Category.Animal" },    // Truffle
+			{ "437", "Category.Animal" },    // Red Slime Egg
+			{ "439", "Category.Animal" },    // Purple Slime Egg
+			{ "440", "Category.Animal" },    // Wool
+			{ "442", "Category.Animal" },    // Duck Egg
+			{ "444", "Category.Animal" },    // Duck Feather
+			{ "446", "Category.Animal" },    // Rabbit's Foot
+			{ "680", "Category.Animal" },    // Green Slime Egg
+			{ "857", "Category.Animal" },    // Tiger Slime Egg
+			{ "928", "Category.Animal" },    // Golden Egg
+
 			{ "18", "Category.Spring" },     // Daffodil
 			{ "22", "Category.Spring" },     // Dandelion
 			{ "20", "Category.Spring" },     // Leek
@@ -193,7 +212,6 @@ namespace AutoForager.Helpers
 			{ "829",  "Category.Special" },  // Ginger
 			{ "Moss", "Category.Special" },  // Moss
 			{ "399",  "Category.Special" },  // Sping Onion
-			{ "430",  "Category.Special" },  // Truffle
 		};
 		public static Dictionary<string, string> KnownCategoryLookup => _knownCategoryLookup;
 

--- a/src/AutoForager/Integrations/FarmTypeManagerWrapper.cs
+++ b/src/AutoForager/Integrations/FarmTypeManagerWrapper.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using StardewModdingAPI;
+using HedgeTech.Common.Extensions;
+
+namespace AutoForager.Integrations
+{
+	internal class FarmTypeManagerWrapper
+	{
+		private const string _minVersion = "1.20.0";
+		private const string _ftmUniqueId = "Esca.FarmTypeManager";
+		private const int _readyRetries = 120;
+		private const int _readyRetryWaitMs = 500;
+
+		private readonly IMonitor _monitor;
+		private readonly IModHelper _helper;
+
+		private readonly IFarmTypeManagerApi? _ftmApi;
+
+		private IDictionary<string, IEnumerable<string>> _forageIdsPerContentPack;
+		public IDictionary<string, IEnumerable<string>> ForageIdsPerContentPack => _forageIdsPerContentPack;
+
+		public FarmTypeManagerWrapper(IMonitor monitor, IModHelper helper)
+		{
+			_monitor = monitor;
+			_helper = helper;
+			_forageIdsPerContentPack = new Dictionary<string, IEnumerable<string>>();
+
+			if (helper.ModRegistry.IsLoaded(_ftmUniqueId))
+			{
+				var ftm = helper.ModRegistry.Get(_ftmUniqueId);
+
+				if (ftm is not null)
+				{
+					var ftmName = ftm.Manifest.Name;
+					var ftmVersion = ftm.Manifest.Version;
+
+					if (ftmVersion.IsEqualToOrNewerThan(_minVersion))
+					{
+						monitor.Log(I18n.Log_Wrapper_ModFound(ftmName, I18n.Subject_SpawnableForageIds()), LogLevel.Info);
+						_ftmApi = helper.ModRegistry.GetApi<IFarmTypeManagerApi>(_ftmUniqueId);
+					}
+					else
+					{
+						monitor.Log(I18n.Log_Wrapper_OldVersion(ftmName, ftmVersion, _minVersion), LogLevel.Warn);
+					}
+				}
+				else
+				{
+					monitor.Log(I18n.Log_Wrapper_ManifestError("Farm Type Manager"), LogLevel.Warn);
+				}
+			}
+		}
+
+		public IDictionary<string, IEnumerable<string>> UpdateForageIds()
+		{
+			if (_ftmApi is not null)
+			{
+				_forageIdsPerContentPack = _ftmApi.GetForageIDsFromContentPacks();
+			}
+
+			return _forageIdsPerContentPack;
+		}
+	}
+
+	/// <summary>The public API interface for Farm Type Manager (FTM), provided through SMAPI's mod helper.</summary>
+	public interface IFarmTypeManagerApi
+	{
+		/// <summary>Gets information about all the valid forage IDs in loaded FTM content packs. Keys are content pack IDs (or "" for other sources). Values are a list of each valid, qualified item ID.</summary>
+		/// <remarks>
+		/// This method will produce information about the current in-game day.
+		/// It is available as soon as SMAPI has loaded all content packs, e.g. during GameLaunched events.
+		/// Results may change after FTM's DayStarted events, during which FTM reloads all content pack data.
+		/// Data from save-specific personal config files will only be included if "Context.IsWorldReady" is true.
+		/// </remarks>
+		/// <param name="includePlacedItems">If true, this list will include the IDs of forage items that are NOT normal <see cref="StardewValley.Object"/> instances. These spawn inside a custom <see cref="TerrainFeature"/> subclass, but imitate most normal forage behavior.</param>
+		/// <param name="includeContainers">If true, this list will include the IDs of containers that are spawned as forage (chests, breakable barrels and crates, etc).</param>
+		public IDictionary<string, IEnumerable<string>> GetForageIDsFromContentPacks(bool includePlacedItems = false, bool includeContainers = false);
+	}
+}

--- a/src/AutoForager/ModConfig.cs
+++ b/src/AutoForager/ModConfig.cs
@@ -42,6 +42,12 @@ namespace AutoForager
 
 		public bool ForageSeedSpots { get; set; }
 
+		public bool ForageMushroomBoxes { get; set; }
+
+		public bool ForageMushroomLogs { get; set; }
+
+		public bool ForageTappers { get; set; }
+
 		public Dictionary<string, Dictionary<string, bool>> ForageToggles { get; set; }
 
 		private bool _anyBushesEnabled;
@@ -97,6 +103,9 @@ namespace AutoForager
 
 			ForageArtifactSpots = true;
 			ForageSeedSpots = true;
+			ForageMushroomBoxes = true;
+			ForageMushroomLogs = true;
+			ForageTappers = true;
 
 			foreach (var toggleDict in ForageToggles)
 			{
@@ -253,6 +262,7 @@ namespace AutoForager
 					gmcmApi.AddBoolOption(
 						mod: manifest,
 						name: () => I18n.Option_ToggleAction_Name(item.DisplayName),
+						tooltip: () => $"{item.ItemId} - {item.InternalName}",
 						getValue: () => item.IsEnabled,
 						setValue: val =>
 						{
@@ -300,6 +310,7 @@ namespace AutoForager
 					gmcmApi.AddBoolOption(
 						mod: manifest,
 						name: () => I18n.Option_ToggleAction_Name(item.DisplayName),
+						tooltip: () => $"{item.ItemId} - {item.InternalName}",
 						getValue: () => item.IsEnabled,
 						setValue: val =>
 						{
@@ -447,6 +458,39 @@ namespace AutoForager
 				getValue: () => ForageSeedSpots,
 				setValue: (val) => ForageSeedSpots = val);
 
+			// Mushroom Boxes
+			gmcmApi.AddBoolOption(
+				mod: manifest,
+				name: () => I18n.Option_ToggleAction_Name(I18n.Subject_MushroomBoxes()),
+				tooltip: () => I18n.Option_ToggleAction_Description_Reward(
+					I18n.Action_Forage_Future().ToLowerInvariant(),
+					I18n.Subject_MushroomBoxes(),
+					I18n.Reward_Mushrooms()),
+				getValue: () => ForageMushroomBoxes,
+				setValue: (val) => ForageMushroomBoxes = val);
+
+			// Mushroom Logs
+			gmcmApi.AddBoolOption(
+				mod: manifest,
+				name: () => I18n.Option_ToggleAction_Name(I18n.Subject_MushroomLogs()),
+				tooltip: () => I18n.Option_ToggleAction_Description_Reward(
+					I18n.Action_Forage_Future().ToLowerInvariant(),
+					I18n.Subject_MushroomLogs(),
+					I18n.Reward_Mushrooms()),
+				getValue: () => ForageMushroomLogs,
+				setValue: (val) => ForageMushroomLogs = val);
+
+			// Tappers
+			gmcmApi.AddBoolOption(
+				mod: manifest,
+				name: () => I18n.Option_ToggleAction_Name(I18n.Subject_Tappers()),
+				tooltip: () => I18n.Option_ToggleAction_Description_Reward(
+					I18n.Action_Forage_Future().ToLowerInvariant(),
+					I18n.Subject_Tappers(),
+					I18n.Reward_TappedTree()),
+				getValue: () => ForageTappers,
+				setValue: (val) => ForageTappers = val);
+
 			gmcmApi.AddParagraph(
 				mod: manifest,
 				text: I18n.Page_Forageables_Description);
@@ -462,6 +506,7 @@ namespace AutoForager
 					gmcmApi.AddBoolOption(
 						mod: manifest,
 						name: () => I18n.Option_ToggleAction_Name(item.DisplayName),
+						tooltip: () => $"{item.ItemId} - {item.InternalName}",
 						getValue: () => item.IsEnabled,
 						setValue: val =>
 						{

--- a/src/AutoForager/ModConfig.cs
+++ b/src/AutoForager/ModConfig.cs
@@ -18,7 +18,7 @@ namespace AutoForager
 		private const string _gmcmUniqueId = "spacechase0.GenericModConfigMenu";
 
 		private readonly ForageableItemTracker _forageableTracker;
-		private IComparer<string> _comparer = new CategoryComparer();
+		private CategoryComparer _comparer = new();
 		private IMonitor? _monitor;
 		private JsonHelper _jsonHelper;
 
@@ -75,6 +75,11 @@ namespace AutoForager
 			_monitor = monitor;
 			_comparer = new CategoryComparer(packs);
 			_jsonHelper = jsonHelper;
+		}
+
+		public void AddFtmCategories(Dictionary<string, string> ftmCategories)
+		{
+			_comparer.AddFtmCategories(ftmCategories);
 		}
 
 		public void ResetToDefault()

--- a/src/AutoForager/README.md
+++ b/src/AutoForager/README.md
@@ -55,7 +55,11 @@ Ukrainian  | ✔              | ❌                   | ❌                | n/a
   - SMAPI 4.0.0 or later
 - Automatic Integrations
   - [Bush Bloom Mod](https://www.nexusmods.com/stardewvalley/mods/15792)
+    - Minimum version: **1.1.9**
   - [Custom Bush](https://www.nexusmods.com/stardewvalley/mods/20619)
+    - Minimum version: **1.0.4**
+  - [Farm Type Manager](https://www.nexusmods.com/stardewvalley/mods/3231)
+    - Minimum version: **1.20.0**
 - No known mod conflicts
   - If you find one, please feel free to notify me here on Github, on the [Nexus Mod](https://www.nexusmods.com/stardewvalley/mods/7736) site, or on the [CurseForge](https://www.curseforge.com/stardewvalley/mods/auto-forager) site.
 
@@ -65,6 +69,12 @@ Ukrainian  | ✔              | ❌                   | ❌                | n/a
 
 ## Releases
 Releases can be found on [GitHub](https://github.com/Hedgehog-Technologies/StardewMods/releases), on the [Nexus Mod](https://www.nexusmods.com/stardewvalley/mods/7736) site, and on the [CurseForge](https://www.curseforge.com/stardewvalley/mods/auto-forager) site.
+### 3.5.0
+- Add automatic integration with Farm Type Manager
+  - Content packs should no longer be needed going forward but will continue to work
+  - Category names will likely be different as they are now pulled from the FTM content pack instead of the AF content packs
+  - Shoutout to [Esca-MMC](https://github.com/Esca-MMC) for supplying the API
+- Add Animal products as a category for vanilla animal products
 ### 3.4.3
 - Add additional safeguards around players clicking through title menu quickly
 ### 3.4.2

--- a/src/AutoForager/README.md
+++ b/src/AutoForager/README.md
@@ -70,11 +70,14 @@ Ukrainian  | ✔              | ❌                   | ❌                | n/a
 ## Releases
 Releases can be found on [GitHub](https://github.com/Hedgehog-Technologies/StardewMods/releases), on the [Nexus Mod](https://www.nexusmods.com/stardewvalley/mods/7736) site, and on the [CurseForge](https://www.curseforge.com/stardewvalley/mods/auto-forager) site.
 ### 3.5.0
-- Add automatic integration with Farm Type Manager
+- Add automatic integration with [Farm Type Manager](https://www.nexusmods.com/stardewvalley/mods/3231)
   - Content packs should no longer be needed going forward but will continue to work
   - Category names will likely be different as they are now pulled from the FTM content pack instead of the AF content packs
+  - Minimum version: **1.20.0**
   - Shoutout to [Esca-MMC](https://github.com/Esca-MMC) for supplying the API
+- Add options to forage Mushroom Boxes, Mushroom Logs, and Tappers
 - Add Animal products as a category for vanilla animal products
+- Add vanilla Fruit forageable toggles to help with the Fruit Bat cave option
 ### 3.4.3
 - Add additional safeguards around players clicking through title menu quickly
 ### 3.4.2

--- a/src/AutoForager/i18n/default.json
+++ b/src/AutoForager/i18n/default.json
@@ -2,6 +2,7 @@
   "Action.Shake.Future": "Shake",
   "Action.Dig.Future": "Dig Up",
 
+  "Category.Animal": "Animals",
   "Category.Beach": "Beach",
   "Category.BushBlooms": "Bush Blooms",
   "Category.CustomBushes": "Custom Bushes",
@@ -94,6 +95,7 @@
   "Subject.GingerRoots": "Ginger roots",
   "Subject.SalmonberryBushes": "Salmonberry bushes",
   "Subject.SeedSpot": "Seed Spot",
+  "Subject.SpawnableForageIds": "spawnable forage ids",
   "Subject.TeaBushes": "Tea bushes",
   "Subject.WalnutBushes": "Walnut bushes"
 }

--- a/src/AutoForager/i18n/default.json
+++ b/src/AutoForager/i18n/default.json
@@ -1,6 +1,7 @@
 ﻿{
-  "Action.Shake.Future": "Shake",
   "Action.Dig.Future": "Dig Up",
+  "Action.Forage.Future": "Forage",
+  "Action.Shake.Future": "Shake",
 
   "Category.Animal": "Animals",
   "Category.Beach": "Beach",
@@ -77,7 +78,9 @@
   "Reward.Buried.Items": "Buried Items",
   "Reward.Buried.Seeds": "Buried Seeds",
   "Reward.GoldenWalnuts": "Golden Walnuts",
+  "Reward.Mushrooms": "Mushrooms",
   "Reward.Salmonberries": "Salmonberries",
+  "Reward.TappedTree": "Tree Byproducts",
   "Reward.TeaLeaves": "Tea Leaves",
 
   "Section.Bushes.Text": "Bush Toggles",
@@ -93,9 +96,12 @@
   "Subject.Bushes": "bushes",
   "Subject.BushBloomSchedules": "bush bloom schedules",
   "Subject.GingerRoots": "Ginger roots",
+  "Subject.MushroomBoxes": "Mushroom Boxes",
+  "Subject.MushroomLogs": "Mushroom Logs",
   "Subject.SalmonberryBushes": "Salmonberry bushes",
   "Subject.SeedSpot": "Seed Spot",
   "Subject.SpawnableForageIds": "spawnable forage ids",
+  "Subject.Tappers": "Tappers",
   "Subject.TeaBushes": "Tea bushes",
   "Subject.WalnutBushes": "Walnut bushes"
 }

--- a/src/AutoForager/i18n/es.json
+++ b/src/AutoForager/i18n/es.json
@@ -1,7 +1,9 @@
 ﻿{
-  "Action.Shake.Future": "Zarandear",
   "Action.Dig.Future": "Cavar",
+  "Action.Forage.Future": "Forage", // TODO
+  "Action.Shake.Future": "Zarandear",
 
+  "Category.Animal": "Animals", // TODO
   "Category.Beach": "Playa",
   "Category.BushBlooms": "Florecimiento de arbustos",
   "Category.CustomBushes": "Arbustos personalizados",
@@ -76,7 +78,9 @@
   "Reward.Buried.Items": "Objetos enterrados",
   "Reward.Buried.Seeds": "Semillas enterradas",
   "Reward.GoldenWalnuts": "Nueces doradas",
+  "Reward.Mushrooms": "Mushrooms", // TODO
   "Reward.Salmonberries": "Frambuesas",
+  "Reward.TappedTree": "Tree Byproducts", // TODO
   "Reward.TeaLeaves": "Hojas de té",
 
   "Section.Bushes.Text": "Cambiar arbustos",
@@ -92,8 +96,12 @@
   "Subject.Bushes": "arbustos",
   "Subject.BushBloomSchedules": "calendario de florecimiento de arbustos",
   "Subject.GingerRoots": "Raíces de jengibre",
+  "Subject.MushroomBoxes": "Mushroom Boxes", // TODO
+  "Subject.MushroomLogs": "Mushroom Logs", // TODO
   "Subject.SalmonberryBushes": "Arbusto de frambuesas",
   "Subject.SeedSpot": "Lugar de semilla",
+  "Subject.SpawnableForageIds": "spawnable forage ids", // TODO
+  "Subject.Tappers": "Tappers", // TODO
   "Subject.TeaBushes": "Arbustos de té",
   "Subject.WalnutBushes": "Arbustos de nueces"
 }

--- a/src/AutoForager/i18n/pt-BR.json
+++ b/src/AutoForager/i18n/pt-BR.json
@@ -1,7 +1,9 @@
-{
-  "Action.Shake.Future": "Agite",
+﻿{
   "Action.Dig.Future": "Desenterrar", // Google Translate - Feel free to update
+  "Action.Forage.Future": "Forage", // TODO
+  "Action.Shake.Future": "Agite",
 
+  "Category.Animal": "Animals", // TODO
   "Category.Beach": "Praia", // Google Translate - Feel free to update
   "Category.BushBlooms": "Flores de Arbustos", // Google Translate - Feel free to update
   "Category.CustomBushes": "Arbustos Personalizados", // Google Translate - Feel free to update
@@ -76,7 +78,9 @@
   "Reward.Buried.Items": "Itens Enterrados", // Google Translate - Feel free to update
   "Reward.Buried.Seeds": "Sementes Enterradas", // Google Translate - Feel free to update
   "Reward.GoldenWalnuts": "GWalnuts antigos",
+  "Reward.Mushrooms": "Mushrooms", // TODO
   "Reward.Salmonberries": "Salmonberries",
+  "Reward.TappedTree": "Tree Byproducts", // TODO
   "Reward.TeaLeaves": "Folhas de Chá",
 
   "Section.Bushes.Text": "Alterrâncias de Bush",
@@ -92,8 +96,12 @@
   "Subject.Bushes": "arbustos", // Google Translate - Feel free to update
   "Subject.BushBloomSchedules": "horários de floração do mato", // Google Translate - Feel free to update
   "Subject.GingerRoots": "Raízes de gengibre",
+  "Subject.MushroomBoxes": "Mushroom Boxes", // TODO
+  "Subject.MushroomLogs": "Mushroom Logs", // TODO
   "Subject.SalmonberryBushes": "Arbustos de salmão",
   "Subject.SeedSpot": "Localização da semente", // Google Translate - Feel free to update
+  "Subject.SpawnableForageIds": "spawnable forage ids", // TODO
+  "Subject.Tappers": "Tappers", // TODO
   "Subject.TeaBushes": "Arbustos de chá",
   "Subject.WalnutBushes": "Arbustos de nozes"
 }

--- a/src/AutoForager/i18n/zh.json
+++ b/src/AutoForager/i18n/zh.json
@@ -1,7 +1,9 @@
 ﻿{
-  "Action.Shake.Future": "摇晃",
   "Action.Dig.Future": "挖出", // Google Translate - Feel free to update
+  "Action.Forage.Future": "Forage", // TODO
+  "Action.Shake.Future": "摇晃",
 
+  "Category.Animal": "Animals", // TODO
   "Category.Beach": "海滩", // Google Translate - Feel free to update
   "Category.BushBlooms": "布什绽放", // Google Translate - Feel free to update
   "Category.CustomBushes": "定制灌木丛", // Google Translate - Feel free to update
@@ -76,7 +78,9 @@
   "Reward.Buried.Items": "埋藏物品", // Google Translate - Feel free to update
   "Reward.Buried.Seeds": "埋藏的种子", // Google Translate - Feel free to update
   "Reward.GoldenWalnuts": "金胡桃",
+  "Reward.Mushrooms": "Mushrooms", // TODO
   "Reward.Salmonberries": "树莓",
+  "Reward.TappedTree": "Tree Byproducts", // TODO
   "Reward.TeaLeaves": "茶叶",
 
   "Section.Bushes.Text": "灌木丛 切换",
@@ -92,8 +96,12 @@
   "Subject.Bushes": "灌木丛", // Google Translate - Feel free to update
   "Subject.BushBloomSchedules": "布什开花时间表", // Google Translate - Feel free to update
   "Subject.GingerRoots": "姜",
+  "Subject.MushroomBoxes": "Mushroom Boxes", // TODO
+  "Subject.MushroomLogs": "Mushroom Logs", // TODO
   "Subject.SalmonberryBushes": "树莓灌木",
   "Subject.SeedSpot": "种子位置", // Google Translate - Feel free to update
+  "Subject.SpawnableForageIds": "spawnable forage ids", // TODO
+  "Subject.Tappers": "Tappers", // TODO
   "Subject.TeaBushes": "茶苗",
   "Subject.WalnutBushes": "核桃树丛"
 }


### PR DESCRIPTION
- Add automatic integration with [Farm Type Manager](https://www.nexusmods.com/stardewvalley/mods/3231)
  - Content packs should no longer be needed going forward but will continue to work
  - Category names will likely be different as they are now pulled from the FTM content pack instead of the AF content packs
  - Minimum version: **1.20.0**
  - Shoutout to [Esca-MMC](https://github.com/Esca-MMC) for supplying the API
- Add options to forage Mushroom Boxes, Mushroom Logs, and Tappers
- Add Animal products as a category for vanilla animal products
- Add vanilla Fruit forageable toggles to help with the Fruit Bat cave option